### PR TITLE
Refactor attempt result handling and typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.1] - 2025-07-22
+
+### Added
+- `getAttemptStatus`, `SUCCEEDED`, and `FAILED` exports for standardized status handling.
+
+### Changed
+- Improved type safety and clarity of `AttemptResult`, `AttemptSuccess`, and `AttemptFailure`.
+- Enhanced `fail()` with additional overloads and better documentation.
+- Refined value and error extraction utilities.
+- Strengthened tests with stricter error handling and status checks.
+
 ## [v1.0.0] - 2025-07-16
 
 Initial Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/attempt",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Run synchronous and asynchronous code without throwing errors",
   "keywords": [
     "try",


### PR DESCRIPTION
Improves type safety and clarity for AttemptResult, AttemptSuccess, and AttemptFailure. Adds getAttemptStatus, SUCCEEDED, and FAILED exports, refines error/value extraction, and updates tests for stricter error handling and status checks. Enhances documentation and overloads for fail().

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
