### PR TITLE
Add attemptAll utility and improve handleResultAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.3] - 2025-07-30
+
+### Added
+- Added `attemptAll` function to execute multiple callbacks sequentially, passing the result of each callback to the next.
+- Add support for `AbortSignal`s in `handleResultAsync`
+
 ## [v1.0.2] - 2025-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm i @aegisjsproject/attempt
 <script type="importmap">
   {
     "imports": {
-      "@aegisjsproject/attempt": "https://unpkg.com/@aegisjsproject/attempt@1.0.0/attempt.min.js"
+      "@aegisjsproject/attempt": "https://unpkg.com/@aegisjsproject/attempt@1.0.3/attempt.min.js"
     }
   }
 </script>
@@ -87,6 +87,7 @@ npm i @aegisjsproject/attempt
 | **`handleResultAsync(result, { success, failure })`** | Handles an `AttemptResult` asynchronously by invoking the appropriate callback.                      |
 | **`handleResultSync(result, { success, failure })`**  | Handles an `AttemptResult` synchronously by invoking the appropriate callback.                       |
 | **`throwIfFailed(result)`**                           | Handle errors the typical `try/catch` way by throwing the error in an `AttemptFailure`.              |
+| **`attemptAll(...callbacks)`**                        | Attempts to execute multiple callbacks sequentially, passing the result of each callback to the next.|
 
 ## Requirements
 
@@ -149,4 +150,20 @@ safeParse('{Invalid JSON}');
 const [value, error] = await attemptAsync(fetch, '/api', { signal: AbortSignal.abort('Request cancelled') });
 if (error) { … }           // always an Error instance
 else       { …value… }     // may be any value (even null/undefined)
+```
+
+### Using `attemptAll()`
+
+```js
+import { attemptAll } from '@aegisjsproject/attempt';
+
+const [sri] = await attemptAll(
+  () => import('node:fs/promises'),
+  fs => fs.readFile('/path/to/file.txt', 'utf8'),
+  text => new TextEncoder().encode(text),
+  encoded => crypto.subtle.digest('SHA-256', encoded),
+  hash => new Uint8Array(hash),
+  bytes => bytes.toBase64(),
+  hash => `sha256-${hash}`
+);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/attempt",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Run synchronous and asynchronous code without throwing errors",
   "keywords": [
     "try",


### PR DESCRIPTION
Introduces the attemptAll function to execute multiple callbacks sequentially, propagating results. Enhances handleResultAsync to support abort signals, returning a failure if aborted before execution.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
