### PR TITLE
Add toStringTag and refactor attemptAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.6] - 2025-08-13
+
+### Added
+- Add `Symbol.toStringTag` getters for `AttemptSuccess` & `AttemptFailure`, and `toString()` on `AttemptResult`
+
+### Changed
+- Refactor `attemptAll()` to simplify & improve performance
+
 ## [v1.0.5] - 2025-08-10
 
 ### Added

--- a/attempt.test.js
+++ b/attempt.test.js
@@ -39,6 +39,9 @@ describe('Test `attempt` library', async () => {
 		const aborted = fail(sig);
 		const abortedStr = fail(AbortSignal.abort('failed'));
 
+		strictEqual(good.toString(), '[object AttemptSuccess]', '`AttemptSuccess should stringify as the correct object type.');
+		strictEqual(bad.toString(), '[object AttemptFailure]', '`AttemptFailure should stringify as the correct object type.');
+
 		throws(() => new AttemptResult('true', 'false', false), 'Should not be able to construct `AttemptResult` directly.');
 		ok(good.ok, 'Successful results should have `ok` set to `true`.');
 		ok(! bad.ok, 'Failed results should have `ok` set to `false`.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/attempt",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/attempt",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Run synchronous and asynchronous code without throwing errors",
   "keywords": [
     "try",


### PR DESCRIPTION
Introduces Symbol.toStringTag getters for AttemptSuccess and AttemptFailure, and a toString() method for AttemptResult. Refactors attemptAll() to use Promise.reduce for improved performance and simplicity. Updates tests to verify new stringification behavior.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
